### PR TITLE
Fix failure to download files by handling connection redirect to new URL

### DIFF
--- a/src/de/lazyzero/kkMulticopterFlashTool/KKMulticopterFlashTool.java
+++ b/src/de/lazyzero/kkMulticopterFlashTool/KKMulticopterFlashTool.java
@@ -629,13 +629,10 @@ public class KKMulticopterFlashTool extends JFrame implements
 			}
 
 		} catch (Exception e) {
-			
-			e.printStackTrace();
 			firmwareRepositoryURL.put("firmwareRepositoryURL", "http://www.chrmoll.de/_media/firmwares.xml.zip");
 			offlineMode = false;
 			
 			saveSettings();
-			e.printStackTrace();
 		}
 	}
 

--- a/src/de/lazyzero/kkMulticopterFlashTool/utils/Firmware.java
+++ b/src/de/lazyzero/kkMulticopterFlashTool/utils/Firmware.java
@@ -26,7 +26,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.text.DecimalFormat;
+import java.net.URLConnection;
 import java.util.Enumeration;
 import java.util.Formatter;
 import java.util.HashMap;
@@ -271,6 +271,12 @@ public class Firmware {
 		
 		if (!tmpFile.exists() || reload) {
     		try {
+    			URLConnection connection = url.openConnection();
+    			String redirect = connection.getHeaderField("Location");
+    			if (redirect != null){
+    			    url = new URL(redirect);
+    			}
+    			
     			BufferedInputStream in = new BufferedInputStream(url.openStream());
     			FileOutputStream fos = new FileOutputStream(tmpFile);
     			BufferedOutputStream bout = new BufferedOutputStream(fos,1024);

--- a/src/de/lazyzero/kkMulticopterFlashTool/utils/XmlReaderFirmwares.java
+++ b/src/de/lazyzero/kkMulticopterFlashTool/utils/XmlReaderFirmwares.java
@@ -29,6 +29,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.URLConnection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Enumeration;
@@ -377,12 +378,19 @@ public class XmlReaderFirmwares {
         filename = tmpdir + filename;
         	
 		File tmpFile = new File(filename);
-		if ((new File(tmpdir)).mkdir()) System.out.println("tmpdir created");
+		if ((new File(tmpdir)).mkdir()) 
+			System.out.println("tmpdir created");
 		
 		
     		try {
     			long time = System.currentTimeMillis();
 //    			ZipInputStream in  = new ZipInputStream(url.openStream());
+    			URLConnection connection = url.openConnection();
+    			String redirect = connection.getHeaderField("Location");
+    			if (redirect != null){
+    			    url = new URL(redirect);
+    			}
+    			
     			BufferedInputStream in = new BufferedInputStream(url.openStream());
     			FileOutputStream fos = new FileOutputStream(tmpFile);
     			BufferedOutputStream bout = new BufferedOutputStream(fos,1024);


### PR DESCRIPTION
Currently when the application tries to read files from the website (the firmwares.xml file and any specific firmware zip files), it is failing
because there is a connection redirect that needs to be handled.

Checks to see if there is a redirect, then fixes the URL to the new
location before downloading.